### PR TITLE
Add sales history screen

### DIFF
--- a/frontend/app/(tabs)/ProfileScreen.tsx
+++ b/frontend/app/(tabs)/ProfileScreen.tsx
@@ -318,8 +318,8 @@ export default function ProfileScreen({ setIsAuthenticated, navigation, route }:
       if (title === 'Объявления на модерацию' && user.role !== UserRole.ADMIN) {
         return null;
       }
-        // Только для админа, продавцов и грузчиков
-      if (title === 'Управление товарами' || title === 'Оффлайн-продажи') {
+      // Только для админа и продавцов
+      if (title === 'Управление товарами' || title === 'Оффлайн-продажи' || title === 'История продаж') {
         if (user.role !== UserRole.ADMIN && user.role !== UserRole.SELLER) {
           return null;
         }
@@ -566,6 +566,7 @@ export default function ProfileScreen({ setIsAuthenticated, navigation, route }:
                 {renderMenuItem('🛍️', 'Мои заказы', () => router.push('/(tabs)/OrdersScreen'))}                {renderMenuItem('📦', 'Управление товарами', () => navigationNative.navigate('ProductManagementScreen'))}
                 {renderMenuItem('📋', 'Поставки', () => setShowSupplyModal(true))}
                 {renderMenuItem('💰', 'Оффлайн-продажи', () => navigationNative.navigate('OfflineSalesScreen'))}
+                {renderMenuItem('📈', 'История продаж', () => navigationNative.navigate('SalesHistory'))}
                 {renderMenuItem('⚖️', 'Объявления на модерацию', () => router.push('/(tabs)/AdsScreen'))}
                 {renderMenuItem('👥', 'Регистрация сотрудника', () => setShowEmployeeRegistration(true))}
                 {renderMenuItem('🚪', 'Выйти', handleLogout, '#FFE5E5')}

--- a/frontend/app/(tabs)/SalesHistoryScreen.tsx
+++ b/frontend/app/(tabs)/SalesHistoryScreen.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator, RefreshControl, ScrollView } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { HeaderBackButton } from '@react-navigation/elements';
+import api from '../api';
+
+interface Sale {
+  id: number;
+  date: string;
+  total: number;
+}
+
+interface Order {
+  id: number;
+  total: number;
+  createdAt: string;
+  status: string;
+}
+
+export default function SalesHistoryScreen() {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [sales, setSales] = useState<Sale[]>([]);
+  const [orders, setOrders] = useState<Order[]>([]);
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerLeft: () => (
+        <HeaderBackButton onPress={() => navigation.goBack()} label="" />
+      )
+    });
+  }, [navigation]);
+
+  const fetchData = async () => {
+    try {
+      const [salesRes, ordersRes] = await Promise.all([
+        api.get('/sales'),
+        api.get('/orders')
+      ]);
+      setSales(salesRes.data || []);
+      const confirmed = (ordersRes.data || []).filter((o: Order) => o.status === 'confirmed');
+      setOrders(confirmed);
+    } catch (e) {
+      console.error('Error fetching sales history:', e);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await fetchData();
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleString('ru-RU', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#2196F3" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={['#2196F3']} />
+      }
+    >
+      <Text style={styles.sectionTitle}>Оффлайн-продажи</Text>
+      {sales.length === 0 ? (
+        <Text style={styles.emptyText}>Записей нет</Text>
+      ) : (
+        sales.map(sale => (
+          <View key={`sale-${sale.id}`} style={styles.item}>
+            <Text style={styles.date}>{formatDate(sale.date)}</Text>
+            <Text style={styles.total}>Сумма: {Number(sale.total).toLocaleString()} ₽</Text>
+          </View>
+        ))
+      )}
+
+      <Text style={styles.sectionTitle}>Закрытые заказы</Text>
+      {orders.length === 0 ? (
+        <Text style={styles.emptyText}>Записей нет</Text>
+      ) : (
+        orders.map(order => (
+          <View key={`order-${order.id}`} style={styles.item}>
+            <Text style={styles.date}>{formatDate(order.createdAt)}</Text>
+            <Text style={styles.total}>Сумма: {Number(order.total).toLocaleString()} ₽</Text>
+          </View>
+        ))
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    padding: 16
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginTop: 16,
+    marginBottom: 8,
+    color: '#333'
+  },
+  item: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 8
+  },
+  date: {
+    fontSize: 14,
+    color: '#666'
+  },
+  total: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: '#000'
+  },
+  emptyText: {
+    textAlign: 'center',
+    color: '#666',
+    marginBottom: 8
+  }
+});

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -17,6 +17,7 @@ import NewSupplyScreen from './NewSupplyScreen';
 import SupplyHistoryScreen from './SupplyHistoryScreen';
 import OrdersScreen from './OrdersScreen';
 import OfflineSalesScreen from './OfflineSalesScreen';
+import SalesHistoryScreen from './SalesHistoryScreen';
 
 const Tab = createBottomTabNavigator();
 const Stack = createNativeStackNavigator();
@@ -76,10 +77,10 @@ function ProfileStack() {
           }
         }} 
       />
-      <Stack.Screen 
-        name="SupplyHistory" 
-        component={SupplyHistoryScreen} 
-        options={{ 
+      <Stack.Screen
+        name="SupplyHistory"
+        component={SupplyHistoryScreen}
+        options={{
           title: 'История поставок',
           headerShown: true,
           headerStyle: {
@@ -89,12 +90,27 @@ function ProfileStack() {
           headerTitleStyle: {
             fontWeight: 'bold',
           }
-        }} 
+        }}
       />
-      <Stack.Screen 
-        name="AddEditProductScreen" 
-        component={AddEditProductScreen} 
-        options={({ route }: any) => ({ 
+      <Stack.Screen
+        name="SalesHistory"
+        component={SalesHistoryScreen}
+        options={{
+          title: 'История продаж',
+          headerShown: true,
+          headerStyle: {
+            backgroundColor: '#fff',
+          },
+          headerTintColor: '#000',
+          headerTitleStyle: {
+            fontWeight: 'bold',
+          }
+        }}
+      />
+      <Stack.Screen
+        name="AddEditProductScreen"
+        component={AddEditProductScreen}
+        options={({ route }: any) => ({
           title: route.params?.product ? 'Редактировать товар' : 'Новый товар',
           headerShown: true,
           headerStyle: {

--- a/frontend/types/navigation.ts
+++ b/frontend/types/navigation.ts
@@ -12,6 +12,7 @@ export type ProfileStackParamList = {
   ProductManagementScreen: undefined;
   NewSupply: undefined;
   SupplyHistory: undefined;
+  SalesHistory: undefined;
   AddEditProductScreen: { product?: any };
 };
 


### PR DESCRIPTION
## Summary
- add SalesHistoryScreen to show offline sales and confirmed online orders
- wire SalesHistoryScreen into profile stack navigation
- expose SalesHistory in navigation types
- show SalesHistory in Profile menu

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in backend *(shows "no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_683f747a45748324bba71c4747f08e0e