### PR TITLE
Add sales history screen

### DIFF
--- a/frontend/app/(tabs)/OrderDetailsScreen.tsx
+++ b/frontend/app/(tabs)/OrderDetailsScreen.tsx
@@ -1,0 +1,126 @@
+import React, { useLayoutEffect } from 'react';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { HeaderBackButton } from '@react-navigation/elements';
+
+export default function OrderDetailsScreen() {
+  const navigation = useNavigation();
+  const { params } = useRoute() as any;
+  const { order } = params || {};
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerLeft: () => (
+        <HeaderBackButton onPress={() => navigation.goBack()} label="" />
+      )
+    });
+  }, [navigation]);
+
+  if (!order) {
+    return (
+      <View style={styles.container}>
+        <Text>Данные заказа недоступны</Text>
+      </View>
+    );
+  }
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleString('ru-RU', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text style={styles.title}>Заказ №{order.id}</Text>
+      <Text style={styles.date}>{formatDate(order.createdAt)}</Text>
+      <Text style={styles.info}>Клиент: {order.name}</Text>
+      {order.deliveryMethod === 'Доставка' && (
+        <Text style={styles.info}>Адрес: {order.address}</Text>
+      )}
+      <Text style={styles.info}>Оплата: {order.paymentMethod}</Text>
+      <View style={styles.itemsContainer}>
+        <Text style={styles.itemsTitle}>Состав заказа:</Text>
+        {order.items.map((item: any, index: number) => (
+          <View key={index} style={styles.itemRow}>
+            <Text style={styles.itemName}>{item.product.name}</Text>
+            <Text style={styles.quantity}>
+              {item.quantity} {item.product.isByWeight ? 'кг' : 'шт'}
+            </Text>
+            <Text style={styles.price}>{Number(item.price).toLocaleString()} ₽</Text>
+          </View>
+        ))}
+      </View>
+      {order.comment ? (
+        <Text style={styles.comment}>Комментарий: {order.comment}</Text>
+      ) : null}
+      <Text style={styles.total}>Итого: {Number(order.total).toLocaleString()} ₽</Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    padding: 16
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 4
+  },
+  date: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 12
+  },
+  info: {
+    fontSize: 15,
+    color: '#333',
+    marginBottom: 4
+  },
+  itemsContainer: {
+    marginTop: 12,
+    marginBottom: 12
+  },
+  itemsTitle: {
+    fontSize: 16,
+    fontWeight: '500',
+    marginBottom: 8
+  },
+  itemRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4
+  },
+  itemName: {
+    flex: 1,
+    color: '#333'
+  },
+  quantity: {
+    width: 60,
+    textAlign: 'right',
+    color: '#666'
+  },
+  price: {
+    width: 80,
+    textAlign: 'right',
+    color: '#333'
+  },
+  comment: {
+    marginTop: 12,
+    color: '#333'
+  },
+  total: {
+    marginTop: 12,
+    fontSize: 16,
+    fontWeight: 'bold',
+    textAlign: 'right',
+    color: '#333'
+  }
+});

--- a/frontend/app/(tabs)/ProfileScreen.tsx
+++ b/frontend/app/(tabs)/ProfileScreen.tsx
@@ -318,8 +318,8 @@ export default function ProfileScreen({ setIsAuthenticated, navigation, route }:
       if (title === 'Объявления на модерацию' && user.role !== UserRole.ADMIN) {
         return null;
       }
-        // Только для админа, продавцов и грузчиков
-      if (title === 'Управление товарами' || title === 'Оффлайн-продажи') {
+      // Только для админа и продавцов
+      if (title === 'Управление товарами' || title === 'Оффлайн-продажи' || title === 'История продаж') {
         if (user.role !== UserRole.ADMIN && user.role !== UserRole.SELLER) {
           return null;
         }
@@ -566,6 +566,7 @@ export default function ProfileScreen({ setIsAuthenticated, navigation, route }:
                 {renderMenuItem('🛍️', 'Мои заказы', () => router.push('/(tabs)/OrdersScreen'))}                {renderMenuItem('📦', 'Управление товарами', () => navigationNative.navigate('ProductManagementScreen'))}
                 {renderMenuItem('📋', 'Поставки', () => setShowSupplyModal(true))}
                 {renderMenuItem('💰', 'Оффлайн-продажи', () => navigationNative.navigate('OfflineSalesScreen'))}
+                {renderMenuItem('📈', 'История продаж', () => navigationNative.navigate('SalesHistory'))}
                 {renderMenuItem('⚖️', 'Объявления на модерацию', () => router.push('/(tabs)/AdsScreen'))}
                 {renderMenuItem('👥', 'Регистрация сотрудника', () => setShowEmployeeRegistration(true))}
                 {renderMenuItem('🚪', 'Выйти', handleLogout, '#FFE5E5')}

--- a/frontend/app/(tabs)/SalesHistoryScreen.tsx
+++ b/frontend/app/(tabs)/SalesHistoryScreen.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator, RefreshControl, ScrollView, TouchableOpacity } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { HeaderBackButton } from '@react-navigation/elements';
+import api from '../api';
+
+interface Sale {
+  id: number;
+  date: string;
+  total: number;
+}
+
+interface Order {
+  id: number;
+  total: number;
+  createdAt: string;
+  status: string;
+}
+
+export default function SalesHistoryScreen() {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [sales, setSales] = useState<Sale[]>([]);
+  const [orders, setOrders] = useState<Order[]>([]);
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerLeft: () => (
+        <HeaderBackButton onPress={() => navigation.goBack()} label="" />
+      )
+    });
+  }, [navigation]);
+
+  const fetchData = async () => {
+    try {
+      const [salesRes, ordersRes] = await Promise.all([
+        api.get('/sales'),
+        api.get('/orders')
+      ]);
+      setSales(salesRes.data || []);
+      const confirmed = (ordersRes.data || []).filter((o: Order) => o.status === 'confirmed');
+      setOrders(confirmed);
+    } catch (e) {
+      console.error('Error fetching sales history:', e);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await fetchData();
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleString('ru-RU', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#2196F3" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={['#2196F3']} />
+      }
+    >
+      <Text style={styles.sectionTitle}>Оффлайн-продажи</Text>
+      {sales.length === 0 ? (
+        <Text style={styles.emptyText}>Записей нет</Text>
+      ) : (
+        sales.map(sale => (
+          <View key={`sale-${sale.id}`} style={styles.item}>
+            <Text style={styles.date}>{formatDate(sale.date)}</Text>
+            <Text style={styles.total}>Сумма: {Number(sale.total).toLocaleString()} ₽</Text>
+          </View>
+        ))
+      )}
+
+      <Text style={styles.sectionTitle}>Закрытые заказы</Text>
+      {orders.length === 0 ? (
+        <Text style={styles.emptyText}>Записей нет</Text>
+      ) : (
+        orders.map(order => (
+          <TouchableOpacity
+            key={`order-${order.id}`}
+            style={styles.item}
+            onPress={() => navigation.navigate('OrderDetails', { order })}
+          >
+            <Text style={styles.date}>{formatDate(order.createdAt)}</Text>
+            <Text style={styles.total}>Сумма: {Number(order.total).toLocaleString()} ₽</Text>
+          </TouchableOpacity>
+        ))
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    padding: 16
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginTop: 16,
+    marginBottom: 8,
+    color: '#333'
+  },
+  item: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 8
+  },
+  date: {
+    fontSize: 14,
+    color: '#666'
+  },
+  total: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: '#000'
+  },
+  emptyText: {
+    textAlign: 'center',
+    color: '#666',
+    marginBottom: 8
+  }
+});

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -17,6 +17,8 @@ import NewSupplyScreen from './NewSupplyScreen';
 import SupplyHistoryScreen from './SupplyHistoryScreen';
 import OrdersScreen from './OrdersScreen';
 import OfflineSalesScreen from './OfflineSalesScreen';
+import SalesHistoryScreen from './SalesHistoryScreen';
+import OrderDetailsScreen from './OrderDetailsScreen';
 
 const Tab = createBottomTabNavigator();
 const Stack = createNativeStackNavigator();
@@ -76,10 +78,10 @@ function ProfileStack() {
           }
         }} 
       />
-      <Stack.Screen 
-        name="SupplyHistory" 
-        component={SupplyHistoryScreen} 
-        options={{ 
+      <Stack.Screen
+        name="SupplyHistory"
+        component={SupplyHistoryScreen}
+        options={{
           title: 'История поставок',
           headerShown: true,
           headerStyle: {
@@ -89,12 +91,38 @@ function ProfileStack() {
           headerTitleStyle: {
             fontWeight: 'bold',
           }
-        }} 
+        }}
       />
-      <Stack.Screen 
-        name="AddEditProductScreen" 
-        component={AddEditProductScreen} 
-        options={({ route }: any) => ({ 
+      <Stack.Screen
+        name="SalesHistory"
+        component={SalesHistoryScreen}
+        options={{
+          title: 'История продаж',
+          headerShown: true,
+          headerStyle: {
+            backgroundColor: '#fff',
+          },
+          headerTintColor: '#000',
+          headerTitleStyle: {
+            fontWeight: 'bold',
+          }
+        }}
+      />
+      <Stack.Screen
+        name="OrderDetails"
+        component={OrderDetailsScreen}
+        options={{
+          title: 'Детали заказа',
+          headerShown: true,
+          headerStyle: { backgroundColor: '#fff' },
+          headerTintColor: '#000',
+          headerTitleStyle: { fontWeight: 'bold' }
+        }}
+      />
+      <Stack.Screen
+        name="AddEditProductScreen"
+        component={AddEditProductScreen}
+        options={({ route }: any) => ({
           title: route.params?.product ? 'Редактировать товар' : 'Новый товар',
           headerShown: true,
           headerStyle: {

--- a/frontend/types/navigation.ts
+++ b/frontend/types/navigation.ts
@@ -12,6 +12,8 @@ export type ProfileStackParamList = {
   ProductManagementScreen: undefined;
   NewSupply: undefined;
   SupplyHistory: undefined;
+  SalesHistory: undefined;
+  OrderDetails: { order: any };
   AddEditProductScreen: { product?: any };
 };
 


### PR DESCRIPTION
## Summary
- add SalesHistoryScreen to show offline sales and confirmed online orders
- wire SalesHistoryScreen into profile stack navigation
- expose SalesHistory in navigation types
- show SalesHistory in Profile menu
- add ability to open order details from sales history

## Testing
- `npm test` *(no output)*
- `npm test` in backend *(shows "Error: no test specified")*


------
https://chatgpt.com/codex/tasks/task_e_683f747a45748324bba71c4747f08e0e