### PR TITLE
Add offline sales detail screen

### DIFF
--- a/frontend/app/(tabs)/SaleDetailsScreen.tsx
+++ b/frontend/app/(tabs)/SaleDetailsScreen.tsx
@@ -1,0 +1,109 @@
+import React, { useLayoutEffect } from 'react';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { HeaderBackButton } from '@react-navigation/elements';
+
+export default function SaleDetailsScreen() {
+  const navigation = useNavigation();
+  const { params } = useRoute() as any;
+  const { sale } = params || {};
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerLeft: () => (
+        <HeaderBackButton onPress={() => navigation.goBack()} label="" />
+      )
+    });
+  }, [navigation]);
+
+  if (!sale) {
+    return (
+      <View style={styles.container}>
+        <Text>Данные продажи недоступны</Text>
+      </View>
+    );
+  }
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleString('ru-RU', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text style={styles.title}>Продажа №{sale.id}</Text>
+      <Text style={styles.date}>{formatDate(sale.date)}</Text>
+      <View style={styles.itemsContainer}>
+        <Text style={styles.itemsTitle}>Состав продажи:</Text>
+        {sale.items.map((item: any, index: number) => (
+          <View key={index} style={styles.itemRow}>
+            <Text style={styles.itemName}>{item.product.name}</Text>
+            <Text style={styles.quantity}>
+              {item.quantity} {item.product.category?.name === 'На развес' ? 'кг' : 'шт'}
+            </Text>
+            <Text style={styles.price}>{Number(item.price).toLocaleString()} ₽</Text>
+          </View>
+        ))}
+      </View>
+      <Text style={styles.total}>Итого: {Number(sale.total).toLocaleString()} ₽</Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    padding: 16
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 4
+  },
+  date: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 12
+  },
+  itemsContainer: {
+    marginTop: 12,
+    marginBottom: 12
+  },
+  itemsTitle: {
+    fontSize: 16,
+    fontWeight: '500',
+    marginBottom: 8
+  },
+  itemRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4
+  },
+  itemName: {
+    flex: 1,
+    color: '#333'
+  },
+  quantity: {
+    width: 60,
+    textAlign: 'right',
+    color: '#666'
+  },
+  price: {
+    width: 80,
+    textAlign: 'right',
+    color: '#333'
+  },
+  total: {
+    marginTop: 12,
+    fontSize: 16,
+    fontWeight: 'bold',
+    textAlign: 'right',
+    color: '#333'
+  }
+});

--- a/frontend/app/(tabs)/SalesHistoryScreen.tsx
+++ b/frontend/app/(tabs)/SalesHistoryScreen.tsx
@@ -104,10 +104,14 @@ export default function SalesHistoryScreen() {
         ? sales.length === 0
           ? (<Text style={styles.emptyText}>Записей нет</Text>)
           : sales.map(sale => (
-              <View key={`sale-${sale.id}`} style={styles.item}>
+              <TouchableOpacity
+                key={`sale-${sale.id}`}
+                style={styles.item}
+                onPress={() => navigation.navigate('SaleDetails', { sale })}
+              >
                 <Text style={styles.date}>{formatDate(sale.date)}</Text>
                 <Text style={styles.total}>Сумма: {Number(sale.total).toLocaleString()} ₽</Text>
-              </View>
+              </TouchableOpacity>
             ))
         : orders.length === 0
           ? (<Text style={styles.emptyText}>Записей нет</Text>)

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -19,6 +19,7 @@ import OrdersScreen from './OrdersScreen';
 import OfflineSalesScreen from './OfflineSalesScreen';
 import SalesHistoryScreen from './SalesHistoryScreen';
 import OrderDetailsScreen from './OrderDetailsScreen';
+import SaleDetailsScreen from './SaleDetailsScreen';
 
 const Tab = createBottomTabNavigator();
 const Stack = createNativeStackNavigator();
@@ -113,6 +114,17 @@ function ProfileStack() {
         component={OrderDetailsScreen}
         options={{
           title: 'Детали заказа',
+          headerShown: true,
+          headerStyle: { backgroundColor: '#fff' },
+          headerTintColor: '#000',
+          headerTitleStyle: { fontWeight: 'bold' }
+        }}
+      />
+      <Stack.Screen
+        name="SaleDetails"
+        component={SaleDetailsScreen}
+        options={{
+          title: 'Детали продажи',
           headerShown: true,
           headerStyle: { backgroundColor: '#fff' },
           headerTintColor: '#000',

--- a/frontend/types/navigation.ts
+++ b/frontend/types/navigation.ts
@@ -14,6 +14,7 @@ export type ProfileStackParamList = {
   SupplyHistory: undefined;
   SalesHistory: undefined;
   OrderDetails: { order: any };
+  SaleDetails: { sale: any };
   AddEditProductScreen: { product?: any };
 };
 


### PR DESCRIPTION
## Summary
- add a `SaleDetailsScreen` to display offline sale info
- register SaleDetails route in navigation
- link offline sales from history to details screen
- update navigation types

## Testing
- `npm run build --prefix backend`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684084ffef4083248dd9019e1b53d788