### PR TITLE
Add personal orders screen

### DIFF
--- a/frontend/app/(tabs)/MyOrdersScreen.tsx
+++ b/frontend/app/(tabs)/MyOrdersScreen.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator, RefreshControl, ScrollView, TouchableOpacity } from 'react-native';
+import { useNavigation, CompositeNavigationProp } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { HeaderBackButton } from '@react-navigation/elements';
+import { TabParamList, ProfileStackParamList } from '../types/navigation';
+import api from './api';
+
+interface Order {
+  id: number;
+  total: number;
+  createdAt: string;
+  status: string;
+}
+
+export default function MyOrdersScreen() {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  type NavigationProp = CompositeNavigationProp<
+    NativeStackNavigationProp<ProfileStackParamList>,
+    BottomTabNavigationProp<TabParamList>
+  >;
+  const navigation = useNavigation<NavigationProp>();
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerLeft: () => (
+        <HeaderBackButton onPress={() => navigation.goBack()} label="" />
+      ),
+      title: 'Мои заказы'
+    });
+  }, [navigation]);
+
+  const fetchOrders = async () => {
+    try {
+      const response = await api.get('/orders');
+      setOrders(response.data || []);
+    } catch (e) {
+      console.error('Error fetching orders:', e);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchOrders();
+  }, []);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await fetchOrders();
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleString('ru-RU', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#2196F3" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={['#2196F3']} />
+      }
+    >
+      {orders.length === 0 ? (
+        <Text style={styles.emptyText}>Записей нет</Text>
+      ) : (
+        orders.map(order => (
+          <TouchableOpacity
+            key={order.id}
+            style={styles.item}
+            onPress={() => navigation.navigate('OrderDetails', { order })}
+          >
+            <Text style={styles.date}>{formatDate(order.createdAt)}</Text>
+            <Text style={styles.status}>Статус: {order.status}</Text>
+            <Text style={styles.total}>Сумма: {Number(order.total).toLocaleString()} ₽</Text>
+          </TouchableOpacity>
+        ))
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    padding: 16
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  item: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 8
+  },
+  date: {
+    fontSize: 14,
+    color: '#666'
+  },
+  status: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 4
+  },
+  total: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: '#000',
+    marginTop: 4
+  },
+  emptyText: {
+    textAlign: 'center',
+    color: '#666',
+    marginTop: 20
+  }
+});

--- a/frontend/app/(tabs)/ProfileScreen.tsx
+++ b/frontend/app/(tabs)/ProfileScreen.tsx
@@ -563,7 +563,8 @@ export default function ProfileScreen({ setIsAuthenticated, navigation, route }:
               {/* Меню действий */}
               <View style={styles.menuContainer}>
                 {renderMenuItem('👤', 'Личные данные', () => setShowPersonalInfo(true))}
-                {renderMenuItem('🛍️', 'Мои заказы', () => router.push('/(tabs)/OrdersScreen'))}                {renderMenuItem('📦', 'Управление товарами', () => navigationNative.navigate('ProductManagementScreen'))}
+                {renderMenuItem('🛍️', 'Мои заказы', () => navigationNative.navigate('MyOrders'))}
+                {renderMenuItem('📦', 'Управление товарами', () => navigationNative.navigate('ProductManagementScreen'))}
                 {renderMenuItem('📋', 'Поставки', () => setShowSupplyModal(true))}
                 {renderMenuItem('💰', 'Оффлайн-продажи', () => navigationNative.navigate('OfflineSalesScreen'))}
                 {renderMenuItem('📈', 'История продаж', () => navigationNative.navigate('SalesHistory'))}

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -16,6 +16,7 @@ import AdsScreen from './AdsScreen';
 import NewSupplyScreen from './NewSupplyScreen';
 import SupplyHistoryScreen from './SupplyHistoryScreen';
 import OrdersScreen from './OrdersScreen';
+import MyOrdersScreen from './MyOrdersScreen';
 import OfflineSalesScreen from './OfflineSalesScreen';
 import SalesHistoryScreen from './SalesHistoryScreen';
 import OrderDetailsScreen from './OrderDetailsScreen';
@@ -107,6 +108,17 @@ function ProfileStack() {
           headerTitleStyle: {
             fontWeight: 'bold',
           }
+        }}
+      />
+      <Stack.Screen
+        name="MyOrders"
+        component={MyOrdersScreen}
+        options={{
+          title: 'Мои заказы',
+          headerShown: true,
+          headerStyle: { backgroundColor: '#fff' },
+          headerTintColor: '#000',
+          headerTitleStyle: { fontWeight: 'bold' }
         }}
       />
       <Stack.Screen

--- a/frontend/types/navigation.ts
+++ b/frontend/types/navigation.ts
@@ -13,6 +13,7 @@ export type ProfileStackParamList = {
   NewSupply: undefined;
   SupplyHistory: undefined;
   SalesHistory: undefined;
+  MyOrders: undefined;
   OrderDetails: { order: any };
   SaleDetails: { sale: any };
   AddEditProductScreen: { product?: any };


### PR DESCRIPTION
## Summary
- allow users to view their orders via new `MyOrdersScreen`
- navigate to new screen from profile
- include screen in profile stack navigation
- extend navigation types

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408808e9e483248e8d27cbeec8e8ef