### PR TITLE
Fix seller chat visibility

### DIFF
--- a/frontend/app/(tabs)/ConsultScreen.tsx
+++ b/frontend/app/(tabs)/ConsultScreen.tsx
@@ -16,6 +16,7 @@ import {
 import { FontAwesome5, Ionicons } from '@expo/vector-icons';
 import { chatHistoryService } from '../../services/chatHistoryService';
 import { chatApi } from '../api';
+import { SELLER_ID } from '../config/env';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRouter } from 'expo-router';
 
@@ -51,7 +52,6 @@ export default function ConsultScreen() {
   const [showAuth, setShowAuth] = useState(false);
   const [userId, setUserId] = useState<number | null>(null);
   const [isAuthChecked, setIsAuthChecked] = useState(false);
-  const SELLER_ID = 1;
 
   useEffect(() => {
     const checkAuth = async () => {

--- a/frontend/app/api.ts
+++ b/frontend/app/api.ts
@@ -2,8 +2,7 @@ import axios, { AxiosError } from 'axios';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainerRef } from '@react-navigation/native';
 import { jwtDecode } from 'jwt-decode';
-
-const API_URL = 'http://192.168.0.102:3000'; // Используйте ваш локальный IP
+import { API_URL } from './config/env';
 
 const api = axios.create({
   baseURL: API_URL,

--- a/frontend/app/config/env.ts
+++ b/frontend/app/config/env.ts
@@ -1,0 +1,2 @@
+export const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://192.168.0.102:3000';
+export const SELLER_ID = process.env.EXPO_PUBLIC_SELLER_ID ? parseInt(process.env.EXPO_PUBLIC_SELLER_ID, 10) : 1;


### PR DESCRIPTION
## Summary
- make API URL and seller id configurable via `env.ts`
- import these settings in API layer and consult screen

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: no test specified)*
- `cd ../frontend && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b892b93c8324bfcb2f3b08175171