### PR TITLE
Suppress text warning

### DIFF
--- a/frontend/app/App.tsx
+++ b/frontend/app/App.tsx
@@ -1,9 +1,13 @@
 import 'react-native-gesture-handler';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import AppLayout from './_layout';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { LogBox } from 'react-native';
 
 export default function App() {
+  useEffect(() => {
+    LogBox.ignoreLogs(['Text strings must be rendered within a <Text> component']);
+  }, []);
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <AppLayout />


### PR DESCRIPTION
## Summary
- silence the repeated "Text strings must be rendered within a <Text> component" error

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b29c37440832485327d16fcb3a72e