### PR TITLE
Separate styles for auth screens

### DIFF
--- a/frontend/app/(auth)/login.tsx
+++ b/frontend/app/(auth)/login.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, Alert } from 'react-native';
+import { styles } from '../styles/LoginScreenStyles';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { login } from '../authApi';
 import { useRouter } from 'expo-router';
@@ -36,15 +37,15 @@ export default function LoginScreen() {
   };
 
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 0, backgroundColor: 'transparent' }}>
-      <View style={{ width: 320, backgroundColor: '#fff', borderRadius: 16, padding: 24, shadowColor: '#000', shadowOpacity: 0.10, shadowRadius: 16, elevation: 8, alignItems: 'stretch' }}>
+    <View style={styles.container}>
+      <View style={styles.innerContainer}>
         <TextInput
           placeholder="Email"
           value={email}
           onChangeText={setEmail}
           autoCapitalize="none"
           keyboardType="email-address"
-          style={{ borderWidth: 1.5, marginBottom: 14, padding: 10, borderRadius: 7, fontSize: 18, backgroundColor: '#f8f9fb', borderColor: '#d1d5db' }}
+          style={[styles.input, { marginBottom: 14 }]}
           placeholderTextColor="#bfc6d1"
         />
         <TextInput
@@ -52,7 +53,7 @@ export default function LoginScreen() {
           value={password}
           onChangeText={setPassword}
           secureTextEntry
-          style={{ borderWidth: 1.5, marginBottom: 20, padding: 10, borderRadius: 7, fontSize: 18, backgroundColor: '#f8f9fb', borderColor: '#d1d5db' }}
+          style={[styles.input, { marginBottom: 20 }]}
           placeholderTextColor="#bfc6d1"
         />
         <Button title={loading ? 'Вход...' : 'Войти'} onPress={handleLogin} disabled={loading} />

--- a/frontend/app/(auth)/register.tsx
+++ b/frontend/app/(auth)/register.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, Alert } from 'react-native';
+import { styles } from '../styles/RegisterScreenStyles';
 import { register } from '../authApi';
 
 export default function RegisterScreen({ navigation }: any) {
@@ -52,13 +53,13 @@ export default function RegisterScreen({ navigation }: any) {
   };
 
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 0, backgroundColor: 'transparent' }}>
-      <View style={{ width: 320, backgroundColor: '#f7f7fa', borderRadius: 16, padding: 24, shadowColor: '#000', shadowOpacity: 0.10, shadowRadius: 16, elevation: 8, alignItems: 'stretch' }}>
+    <View style={styles.container}>
+      <View style={styles.innerContainer}>
         <TextInput
           placeholder="Имя"
           value={name}
           onChangeText={setName}
-          style={{ borderWidth: 1.5, marginBottom: 14, padding: 10, borderRadius: 7, fontSize: 18, backgroundColor: '#fff', borderColor: '#d1d5db' }}
+          style={[styles.input, { marginBottom: 14 }]}
           placeholderTextColor="#bfc6d1"
         />
         <TextInput
@@ -67,7 +68,7 @@ export default function RegisterScreen({ navigation }: any) {
           onChangeText={setEmail}
           autoCapitalize="none"
           keyboardType="email-address"
-          style={{ borderWidth: 1.5, marginBottom: 14, padding: 10, borderRadius: 7, fontSize: 18, backgroundColor: '#fff', borderColor: '#d1d5db' }}
+          style={[styles.input, { marginBottom: 14 }]}
           placeholderTextColor="#bfc6d1"
         />
         <TextInput
@@ -75,7 +76,7 @@ export default function RegisterScreen({ navigation }: any) {
           value={password}
           onChangeText={setPassword}
           secureTextEntry
-          style={{ borderWidth: 1.5, marginBottom: 20, padding: 10, borderRadius: 7, fontSize: 18, backgroundColor: '#fff', borderColor: '#d1d5db' }}
+          style={[styles.input, { marginBottom: 20 }]}
           placeholderTextColor="#bfc6d1"
         />
         <Button title={loading ? 'Регистрация...' : 'Зарегистрироваться'} onPress={handleRegister} disabled={loading} />

--- a/frontend/app/styles/LoginScreenStyles.ts
+++ b/frontend/app/styles/LoginScreenStyles.ts
@@ -1,0 +1,30 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 0,
+    backgroundColor: 'transparent',
+  },
+  innerContainer: {
+    width: 320,
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: '#000',
+    shadowOpacity: 0.10,
+    shadowRadius: 16,
+    elevation: 8,
+    alignItems: 'stretch',
+  },
+  input: {
+    borderWidth: 1.5,
+    padding: 10,
+    borderRadius: 7,
+    fontSize: 18,
+    backgroundColor: '#f8f9fb',
+    borderColor: '#d1d5db',
+  },
+});

--- a/frontend/app/styles/RegisterScreenStyles.ts
+++ b/frontend/app/styles/RegisterScreenStyles.ts
@@ -1,0 +1,30 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 0,
+    backgroundColor: 'transparent',
+  },
+  innerContainer: {
+    width: 320,
+    backgroundColor: '#f7f7fa',
+    borderRadius: 16,
+    padding: 24,
+    shadowColor: '#000',
+    shadowOpacity: 0.10,
+    shadowRadius: 16,
+    elevation: 8,
+    alignItems: 'stretch',
+  },
+  input: {
+    borderWidth: 1.5,
+    padding: 10,
+    borderRadius: 7,
+    fontSize: 18,
+    backgroundColor: '#fff',
+    borderColor: '#d1d5db',
+  },
+});


### PR DESCRIPTION
## Summary
- move inline styles from login and register screens into dedicated style files

## Testing
- `npm test` (fails: jest not found)
- `npm test` in backend (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_684f38a2e9a48324a3243317c13967ec