### PR TITLE
Add note for ad duration

### DIFF
--- a/frontend/app/create-ad.tsx
+++ b/frontend/app/create-ad.tsx
@@ -95,6 +95,10 @@ export default function CreateAdScreen() {
             keyboardType="phone-pad"
           />
 
+          <Text style={styles.note}>
+            Подтверждённое объявление будет отображаться примерно 7 дней
+          </Text>
+
           <TouchableOpacity
             style={[styles.submitButton, isSubmitting && styles.submitButtonDisabled]}
             onPress={handleSubmit}

--- a/frontend/app/styles/CreateAdScreenStyles.ts
+++ b/frontend/app/styles/CreateAdScreenStyles.ts
@@ -53,4 +53,10 @@ export const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
+  note: {
+    fontSize: 14,
+    color: '#666',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
 });


### PR DESCRIPTION
## Summary
- show a note on create ad screen that confirmed ads are visible about 7 days

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851b7e31ab88324bed23c917db896c0