### PR TITLE
Display order update time

### DIFF
--- a/frontend/app/(tabs)/OrdersScreen.tsx
+++ b/frontend/app/(tabs)/OrdersScreen.tsx
@@ -15,6 +15,7 @@ type Order = {
   status: string;
   total: number;
   createdAt: string;
+  updatedAt: string;
   items: Array<{
     productId: number;
     quantity: number;
@@ -114,6 +115,9 @@ export default function OrdersScreen() {
           <View style={styles.orderHeaderLeft}>
             <Text style={styles.orderNumber}>Заказ №{order.id}</Text>
             <Text style={styles.orderDate}>{formatDate(order.createdAt)}</Text>
+            <Text style={styles.orderUpdateDate}>
+              Обновлено: {formatDate(order.updatedAt)}
+            </Text>
           </View>
           <Ionicons 
             name={isExpanded ? 'chevron-up' : 'chevron-down'} 
@@ -148,6 +152,14 @@ export default function OrdersScreen() {
               <Text style={styles.customerInfo}>
                 <Text style={styles.label}>Оплата: </Text>
                 {order.paymentMethod}
+              </Text>
+              <Text style={styles.customerInfo}>
+                <Text style={styles.label}>Статус: </Text>
+                {order.status}
+              </Text>
+              <Text style={styles.customerInfo}>
+                <Text style={styles.label}>Обновлено: </Text>
+                {formatDate(order.updatedAt)}
               </Text>
             </View>
 
@@ -330,6 +342,10 @@ const styles = StyleSheet.create({
   orderDate: {
     fontSize: 14,
     color: '#666',
+  },
+  orderUpdateDate: {
+    fontSize: 12,
+    color: '#999',
   },
   orderInfo: {
     marginBottom: 16,


### PR DESCRIPTION
## Summary
- show the order updated timestamp in Orders screen

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851bd0a7638832488ede011540c38aa