### PR TITLE
Add order status update time

### DIFF
--- a/frontend/app/(tabs)/MyOrdersScreen.tsx
+++ b/frontend/app/(tabs)/MyOrdersScreen.tsx
@@ -12,6 +12,7 @@ interface Order {
   id: number;
   total: number;
   createdAt: string;
+  updatedAt: string;
   status: OrderStatus;
 }
 
@@ -90,9 +91,10 @@ export default function MyOrdersScreen() {
             style={styles.item}
             onPress={() => navigation.navigate('OrderDetails', { order })}
           >
-            <Text style={styles.date}>{formatDate(order.createdAt)}</Text>
-            <Text style={styles.status}>Статус: {getOrderStatusTranslation(order.status)}</Text>
-            <Text style={styles.total}>Сумма: {Number(order.total).toLocaleString()} ₽</Text>
+          <Text style={styles.date}>{formatDate(order.createdAt)}</Text>
+          <Text style={styles.status}>Статус: {getOrderStatusTranslation(order.status)}</Text>
+          <Text style={styles.updatedDate}>Обновлено: {formatDate(order.updatedAt)}</Text>
+          <Text style={styles.total}>Сумма: {Number(order.total).toLocaleString()} ₽</Text>
           </TouchableOpacity>
         ))
       )}
@@ -126,6 +128,10 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#666',
     marginTop: 4
+  },
+  updatedDate: {
+    fontSize: 12,
+    color: '#999'
   },
   total: {
     fontSize: 16,

--- a/frontend/app/(tabs)/OrderDetailsScreen.tsx
+++ b/frontend/app/(tabs)/OrderDetailsScreen.tsx
@@ -40,6 +40,7 @@ export default function OrderDetailsScreen() {
       <Text style={styles.title}>Заказ №{order.id}</Text>
       <Text style={styles.date}>{formatDate(order.createdAt)}</Text>
       <Text style={styles.info}>Статус: {getOrderStatusTranslation(order.status)}</Text>
+      <Text style={styles.date}>Обновлено: {formatDate(order.updatedAt)}</Text>
       <Text style={styles.info}>Клиент: {order.name}</Text>
       {order.deliveryMethod === 'Доставка' && (
         <Text style={styles.info}>Адрес: {order.address}</Text>

--- a/frontend/app/(tabs)/OrdersScreen.tsx
+++ b/frontend/app/(tabs)/OrdersScreen.tsx
@@ -20,6 +20,7 @@ type Order = {
   status: OrderStatus;
   total: number;
   createdAt: string;
+  updatedAt: string;
   items: Array<{
     productId: number;
     quantity: number;
@@ -152,7 +153,7 @@ export default function OrdersScreen() {
     const isExpanded = expandedOrders.includes(order.id);
 
     return (
-      <TouchableOpacity 
+      <TouchableOpacity
         style={styles.orderCard}
         onPress={() => toggleOrderExpansion(order.id)}
       >
@@ -161,6 +162,7 @@ export default function OrdersScreen() {
             <Text style={styles.orderNumber}>Заказ №{order.id}</Text>
             <Text style={styles.orderDate}>{formatDate(order.createdAt)}</Text>
             <Text style={styles.orderStatus}>Статус: {getOrderStatusTranslation(order.status)}</Text>
+            <Text style={styles.orderUpdateDate}>Обновлено: {formatDate(order.updatedAt)}</Text>
           </View>
           <Ionicons 
             name={isExpanded ? 'chevron-up' : 'chevron-down'} 
@@ -395,6 +397,10 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#2196F3',
     marginTop: 4,
+  },
+  orderUpdateDate: {
+    fontSize: 12,
+    color: '#999',
   },
   orderInfo: {
     marginBottom: 16,


### PR DESCRIPTION
## Summary
- show `updatedAt` time for orders so users can see when status changed
- display update time in Order details page
- display update time in orders lists

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851cac4b6548324831616aa638a6397