### PR TITLE
Allow loader to finalize delivery orders

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -788,9 +788,18 @@ app.post('/orders', authMiddleware as any, asyncHandler(async (req: Request, res
 app.post('/orders/:id/confirm', authMiddleware as any, asyncHandler(async (req: Request, res: Response) => {
   const { id } = req.params;
   try {
+    // @ts-ignore
+    const userRole = req.user.role;
     const order = await Order.findByPk(id);
     if (!order) {
       return res.status(404).json({ error: 'Order not found' });
+    }
+
+    if (![UserRole.ADMIN, UserRole.SELLER, UserRole.LOADER].includes(userRole)) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+    if (userRole === UserRole.LOADER && order.deliveryMethod !== 'Доставка') {
+      return res.status(403).json({ error: 'Loaders can only process delivery orders' });
     }
 
     await order.update({ status: 'confirmed' });

--- a/frontend/app/(tabs)/OrdersScreen.tsx
+++ b/frontend/app/(tabs)/OrdersScreen.tsx
@@ -231,7 +231,8 @@ export default function OrdersScreen() {
                 <Text style={styles.confirmButtonText}>Заказ собран</Text>
               </TouchableOpacity>
             )}
-            {(role === UserRole.ADMIN || role === UserRole.SELLER) && (order.status === OrderStatus.READY || order.status === OrderStatus.IN_TRANSIT) && (
+            {(role === UserRole.ADMIN || role === UserRole.SELLER || (role === UserRole.LOADER && order.deliveryMethod === 'Доставка')) &&
+              (order.status === OrderStatus.READY || order.status === OrderStatus.IN_TRANSIT) && (
               <TouchableOpacity
                 style={styles.confirmButton}
                 onPress={(e) => {


### PR DESCRIPTION
## Summary
- enable loaders to finalize delivery orders in the backend
- show finalize button for loaders on delivery orders in the frontend

## Testing
- `npm test` *(fails: Missing script)*
- `cd frontend && npm test`
- `cd ../backend && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851db4611e4832494277020036053fa